### PR TITLE
Added message ID to Test-VmcNotificationWebhook payload

### DIFF
--- a/VMware.VMC.Notification.psd1
+++ b/VMware.VMC.Notification.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VMware.VMC.Notification.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/VMware.VMC.Notification.psm1
+++ b/VMware.VMC.Notification.psm1
@@ -350,6 +350,7 @@ Function Test-VmcNotificationWebhook {
             org_name = "VMC-Customer[0]";
             text = "Test Message";
             message = @{
+                id = "dd768999-d80a-41e1-adc6-b7436506566e";
                 created = "2019-11-05T12:39:45.000811Z";
                 sent = "";
                 failed = "";


### PR DESCRIPTION
Test-VmcNotificationWebhook is failing because of a recent change API change in which we have started to calculate the message signature. In order to do this we need the message ID, which didn't exist in the original test payload.

Signed-off-by: Patrick Kremer <pkremer@vmware.com>